### PR TITLE
feat(redis): Complete Redis-backed task persistence with delayed queu…

### DIFF
--- a/runner/src/main/java/com/distributedscheduler/CoreApplication.java
+++ b/runner/src/main/java/com/distributedscheduler/CoreApplication.java
@@ -3,6 +3,7 @@ package com.distributedscheduler;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 
 @SpringBootApplication(exclude = { DataSourceAutoConfiguration.class })

--- a/runner/src/main/java/com/distributedscheduler/config/RedisConfig.java
+++ b/runner/src/main/java/com/distributedscheduler/config/RedisConfig.java
@@ -1,0 +1,22 @@
+package com.distributedscheduler.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration  // This annotation let Spring register it as a configuration class, and therefore RedisTemplate bean is being created.
+public class RedisConfig {
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        template.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
+        return template;
+    }
+
+}

--- a/runner/src/main/java/com/distributedscheduler/dto/TaskRequest.java
+++ b/runner/src/main/java/com/distributedscheduler/dto/TaskRequest.java
@@ -57,6 +57,14 @@ public class TaskRequest {
     @Min(value = 0, message = "Max retries must be non-negative")
     private int maxRetries = 3;
 
+
+
+
+    @Size(max = 50)
+    private String tenantId = "default";
+
+
+
     /** Default constructor. */
     public TaskRequest() {}
 
@@ -150,5 +158,13 @@ public class TaskRequest {
     /** @param maxRetries Max retry attempts */
     public void setMaxRetries(int maxRetries) {
         this.maxRetries = maxRetries;
+    }
+
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    public void setTenantId(String tenantId) {
+        this.tenantId = tenantId;
     }
 }

--- a/runner/src/main/java/com/distributedscheduler/model/Task.java
+++ b/runner/src/main/java/com/distributedscheduler/model/Task.java
@@ -11,7 +11,7 @@ import org.springframework.data.redis.core.RedisHash;
  * Each task can have dependencies on other tasks and contains its execution status and logs.
  */
 
-@RedisHash("Task")
+
 public class Task {
 
     @Id
@@ -28,6 +28,8 @@ public class Task {
     private Map<String, Object> payload;            // Dynamic input for the task
     private int priority = 0;                       // Task priority (higher = more urgent)
     private int delaySeconds = 0;                   // Optional delay before task execution
+
+    private String tenantId = "default"; // For now, hardcoded
 
     public Task() {
     }
@@ -126,5 +128,14 @@ public class Task {
 
     public void setDelaySeconds(int delaySeconds) {
         this.delaySeconds = delaySeconds;
+    }
+
+
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    public void setTenantId(String tenantId) {
+        this.tenantId = tenantId;
     }
 }

--- a/runner/src/main/java/com/distributedscheduler/redis/RedisDelayQueueService.java
+++ b/runner/src/main/java/com/distributedscheduler/redis/RedisDelayQueueService.java
@@ -9,24 +9,29 @@ import java.util.Set;
 @Service
 public class RedisDelayQueueService {
 
-    private static final String DELAYED_TASKS_KEY = "delayed_tasks";
     private final StringRedisTemplate redisTemplate;
 
     public RedisDelayQueueService(StringRedisTemplate redisTemplate) {
         this.redisTemplate = redisTemplate;
     }
 
-    public void addTaskToDelayQueue(String taskId, long delaySeconds) {
+
+    private String getTenantKey(String tenantId) {
+        return "delayed_tasks:" + tenantId;
+    }
+
+    public void addTaskToDelayQueue(String taskId, String tenantId, long delaySeconds) {
         long score = Instant.now().getEpochSecond() + delaySeconds;
-        redisTemplate.opsForZSet().add(DELAYED_TASKS_KEY, taskId, score);
+        System.out.println("📥 Adding to ZSET: " + taskId + " with score " + score + " for tenant " + tenantId);
+        redisTemplate.opsForZSet().add(getTenantKey(tenantId), taskId, score);
     }
 
-    public Set<String> fetchDueTasks() {
+    public Set<String> fetchDueTasks(String tenantId) {
         long now = Instant.now().getEpochSecond();
-        return redisTemplate.opsForZSet().rangeByScore(DELAYED_TASKS_KEY, 0, now);
+        return redisTemplate.opsForZSet().rangeByScore(getTenantKey(tenantId), 0, now);
     }
 
-    public void removeTask(String taskId) {
-        redisTemplate.opsForZSet().remove(DELAYED_TASKS_KEY, taskId);
+    public void removeTask(String taskId, String tenantId) {
+        redisTemplate.opsForZSet().remove(getTenantKey(tenantId), taskId);
     }
 }

--- a/runner/src/main/java/com/distributedscheduler/redis/RedisTaskStore.java
+++ b/runner/src/main/java/com/distributedscheduler/redis/RedisTaskStore.java
@@ -1,0 +1,30 @@
+package com.distributedscheduler.redis;
+
+import com.distributedscheduler.model.Task;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class RedisTaskStore {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public RedisTaskStore(RedisTemplate<String, Object> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    public void save(Task task) {
+        String key = "task:" + task.getTenantId() + ":" + task.getId();
+        redisTemplate.opsForValue().set(key, task);
+    }
+
+    public Task findById(String tenantId, String taskId) {
+        String key = "task:" + tenantId + ":" + taskId;
+        return (Task) redisTemplate.opsForValue().get(key);
+    }
+
+    public void delete(String tenantId, String taskId) {
+        String key = "task:" + tenantId + ":" + taskId;
+        redisTemplate.delete(key);
+    }
+}

--- a/runner/src/main/java/com/distributedscheduler/repository/TaskRedisRepository.java
+++ b/runner/src/main/java/com/distributedscheduler/repository/TaskRedisRepository.java
@@ -1,7 +1,35 @@
 package com.distributedscheduler.repository;
 
 import com.distributedscheduler.model.Task;
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
 
-public interface TaskRedisRepository extends CrudRepository<Task, String> {
+@Repository
+public class TaskRedisRepository {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public TaskRedisRepository(RedisTemplate<String, Object> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    private String buildKey(String tenantId, String taskId) {
+        return "task:" + tenantId + ":" + taskId;
+    }
+
+    public Task save(Task task) {
+        String key = buildKey(task.getTenantId(), task.getId());
+        redisTemplate.opsForHash().put(key, "data", task); // serialize as a whole
+        return task;
+    }
+
+    public Task findById(String tenantId, String taskId) {
+        String key = buildKey(tenantId, taskId);
+        Object value = redisTemplate.opsForHash().get(key, "data");
+        return value instanceof Task ? (Task) value : null;
+    }
+
+    public void delete(String tenantId, String taskId) {
+        redisTemplate.delete(buildKey(tenantId, taskId));
+    }
 }

--- a/runner/src/main/java/com/distributedscheduler/scheduler/DelayQueuePoller.java
+++ b/runner/src/main/java/com/distributedscheduler/scheduler/DelayQueuePoller.java
@@ -3,27 +3,36 @@ package com.distributedscheduler.scheduler;
 import com.distributedscheduler.redis.RedisDelayQueueService;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import java.util.Set;
+import java.util.List;
 
+import java.time.Instant;
 @Component
 public class DelayQueuePoller {
+    private static final Logger logger = LoggerFactory.getLogger(DelayQueuePoller.class);
 
     private final RedisDelayQueueService delayQueueService;
-
+    // Example tenant list; in production, dynamically fetch this from DB or config
+    private final List<String> tenants = List.of("default", "clientA", "clientB");
     public DelayQueuePoller(RedisDelayQueueService delayQueueService) {
         this.delayQueueService = delayQueueService;
     }
 
     @Scheduled(fixedRate = 1000) // every second
     public void poll() {
-        long now = System.currentTimeMillis();
-        Set<String> readyTaskIds = delayQueueService.getReadyTasks(now);
+        long now = Instant.now().getEpochSecond();
+        for (String tenantId : tenants) {
+            Set<String> readyTaskIds = delayQueueService.fetchDueTasks(tenantId);
 
-        for (String taskId : readyTaskIds) {
-            System.out.println("⏰ Task ready: " + taskId);
-            delayQueueService.removeFromQueue(taskId);
-            // Process task (e.g., update status, enqueue for execution)
+            for (String taskId : readyTaskIds) {
+                logger.info("⏰ Task ready to run: {} (tenant: {})", taskId, tenantId);
+                delayQueueService.removeTask(taskId, tenantId);
+
+                // TODO: Enqueue for execution or update task status in Redis
+                // e.g., taskExecutorService.runTask(taskId);
+            }
         }
     }
 }

--- a/runner/src/test/java/com/distributedscheduler/integration/RedisPersistenceIntegrationTest.java
+++ b/runner/src/test/java/com/distributedscheduler/integration/RedisPersistenceIntegrationTest.java
@@ -1,0 +1,57 @@
+package com.distributedscheduler.integration;
+
+import com.distributedscheduler.model.Task;
+import com.distributedscheduler.model.TaskStatus;
+import com.distributedscheduler.redis.RedisTaskStore;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+public class RedisPersistenceIntegrationTest {
+
+    @Autowired
+    private RedisTaskStore redisTaskStore;
+
+    @Autowired
+    private RedisTemplate<String, Object> redisTemplate;
+
+    @Test
+    public void testTaskPersistenceInRedis() {
+        // Given
+        String tenantId = "integrationTenant";
+        Task task = new Task();
+        task.setId(UUID.randomUUID().toString());
+        task.setName("integration-test-task");
+        task.setTenantId(tenantId);
+        task.setPriority(2);
+        task.setStatus(TaskStatus.PENDING);
+        task.setMaxRetries(2);
+        task.setRetryCount(1);
+        task.setDelaySeconds(5);
+        task.setPayload(Map.of("format", "csv", "source", "db"));
+        task.setDependencies(List.of("dep1", "dep2"));
+
+        // When
+        redisTaskStore.save(task);
+
+        // Then
+        Task fetched = redisTaskStore.findById(task.getTenantId(), task.getId());
+        assertNotNull(fetched);
+        assertEquals(task.getId(), fetched.getId());
+        assertEquals(task.getName(), fetched.getName());
+        assertEquals(task.getTenantId(), fetched.getTenantId());
+        assertEquals(task.getPriority(), fetched.getPriority());
+        assertEquals(task.getStatus(), fetched.getStatus());
+        assertEquals(task.getMaxRetries(), fetched.getMaxRetries());
+        assertEquals(task.getRetryCount(), fetched.getRetryCount());
+        assertEquals(task.getDelaySeconds(), fetched.getDelaySeconds());
+        assertEquals(task.getPayload().get("format"), "csv");
+        assertTrue(fetched.getDependencies().contains("dep1"));
+    }
+}

--- a/runner/src/test/java/com/distributedscheduler/redis/RedisDelayQueueServiceTest.java
+++ b/runner/src/test/java/com/distributedscheduler/redis/RedisDelayQueueServiceTest.java
@@ -1,0 +1,53 @@
+package com.distributedscheduler.redis;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+
+import java.util.Set;
+
+import static org.mockito.Mockito.*;
+
+class RedisDelayQueueServiceTest {
+
+    private RedisDelayQueueService redisDelayQueueService;
+    private StringRedisTemplate redisTemplate;
+    private ZSetOperations<String, String> zSetOperations;
+
+    @BeforeEach
+    void setUp() {
+        redisTemplate = mock(StringRedisTemplate.class);
+        zSetOperations = mock(ZSetOperations.class);
+        when(redisTemplate.opsForZSet()).thenReturn(zSetOperations);
+
+        redisDelayQueueService = new RedisDelayQueueService(redisTemplate);
+    }
+
+    @Test
+    void testAddTaskToDelayQueue() {
+        String taskId = "task-123";
+        String tenantId = "tenantA";
+        long delaySeconds = 60;
+
+        redisDelayQueueService.addTaskToDelayQueue(taskId, tenantId, delaySeconds);
+
+        verify(zSetOperations, times(1)).add(startsWith("delayed_tasks:" + tenantId), eq(taskId), anyDouble());
+    }
+
+    @Test
+    void testFetchDueTasks() {
+        String tenantId = "tenantA";
+        redisDelayQueueService.fetchDueTasks(tenantId);
+        verify(zSetOperations, times(1)).rangeByScore(startsWith("delayed_tasks:" + tenantId), eq(0.0), anyDouble());
+    }
+
+    @Test
+    void testRemoveTask() {
+        String tenantId = "tenantA";
+        String taskId = "task-123";
+        redisDelayQueueService.removeTask(taskId, tenantId);
+        verify(zSetOperations, times(1)).remove(startsWith("delayed_tasks:" + tenantId), eq(taskId));
+    }
+}

--- a/runner/src/test/java/com/distributedscheduler/redis/RedisTaskStoreIntegrationTest.java
+++ b/runner/src/test/java/com/distributedscheduler/redis/RedisTaskStoreIntegrationTest.java
@@ -1,0 +1,61 @@
+
+package com.distributedscheduler.redis;
+
+import com.distributedscheduler.model.Task;
+import com.distributedscheduler.model.TaskStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+public class RedisTaskStoreIntegrationTest {
+
+    @Autowired
+    private RedisTaskStore redisTaskStore;
+
+    @Autowired
+    private RedisTemplate<String, Object> redisTemplate;
+
+    private Task sampleTask;
+
+    @BeforeEach
+    void setup() {
+        sampleTask = new Task();
+        sampleTask.setId(UUID.randomUUID().toString());
+        sampleTask.setName("integration-test-task");
+        sampleTask.setTenantId("testTenant");
+        sampleTask.setPayload(Map.of("key", "value"));
+        sampleTask.setDependencies(List.of("dep1", "dep2"));
+        sampleTask.setStatus(TaskStatus.PENDING);
+        sampleTask.setMaxRetries(5);
+        sampleTask.setDelaySeconds(15);
+        sampleTask.setPriority(3);
+    }
+
+    @Test
+    void testSaveAndFetchTask() {
+        redisTaskStore.save(sampleTask);
+
+        String redisKey = "task:" + sampleTask.getTenantId() + ":" + sampleTask.getId();
+        Task fetched = (Task) redisTemplate.opsForValue().get(redisKey);
+
+        assertNotNull(fetched);
+        assertEquals(sampleTask.getId(), fetched.getId());
+        assertEquals("integration-test-task", fetched.getName());
+        assertEquals("testTenant", fetched.getTenantId());
+        assertEquals(TaskStatus.PENDING, fetched.getStatus());
+        assertEquals(15, fetched.getDelaySeconds());
+        assertEquals(3, fetched.getPriority());
+        assertEquals(5, fetched.getMaxRetries());
+        assertEquals(Map.of("key", "value"), fetched.getPayload());
+        assertEquals(List.of("dep1", "dep2"), fetched.getDependencies());
+    }
+}

--- a/runner/src/test/java/com/distributedscheduler/service.impl/TaskServiceImplTest.java
+++ b/runner/src/test/java/com/distributedscheduler/service.impl/TaskServiceImplTest.java
@@ -3,9 +3,8 @@ package com.distributedscheduler.service.impl;
 import com.distributedscheduler.dto.TaskRequest;
 import com.distributedscheduler.model.Task;
 import com.distributedscheduler.model.TaskStatus;
+import com.distributedscheduler.redis.RedisDelayQueueService;
 import com.distributedscheduler.repository.TaskRedisRepository;
-import com.distributedscheduler.service.impl.TaskServiceImpl;
-import com.distributedscheduler.service.impl.RedisDelayQueueService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -27,8 +26,7 @@ class TaskServiceImplTest {
     void setUp() {
         taskRedisRepository = mock(TaskRedisRepository.class);
         redisDelayQueueService = mock(RedisDelayQueueService.class);
-        taskService = new TaskServiceImpl(taskRedisRepository);
-        taskService.redisDelayQueueService = redisDelayQueueService; // Manually inject if field injection
+        taskService = new TaskServiceImpl(redisDelayQueueService);
     }
 
     @Test
@@ -54,7 +52,7 @@ class TaskServiceImplTest {
         assertEquals("generate-report", result.getName());
         assertEquals(TaskStatus.PENDING, result.getStatus());
         verify(taskRedisRepository, times(1)).save(any(Task.class));
-        verify(redisDelayQueueService, never()).addTaskToDelayQueue(anyString(), anyInt());
+        verify(redisDelayQueueService, never()).addTaskToDelayQueue(anyString(),anyString(), anyInt());
     }
 
     @Test
@@ -75,6 +73,6 @@ class TaskServiceImplTest {
 
         assertEquals("delayed-task", task.getName());
         assertEquals(10, task.getDelaySeconds());
-        verify(redisDelayQueueService).addTaskToDelayQueue(eq(task.getId()), eq(10));
+        verify(redisDelayQueueService).addTaskToDelayQueue(eq(task.getId()),task.getTenantId(), eq(10));
     }
 }

--- a/runner/src/test/java/com/distributedscheduler/service/TaskServiceTest.java
+++ b/runner/src/test/java/com/distributedscheduler/service/TaskServiceTest.java
@@ -3,8 +3,8 @@ package com.distributedscheduler.service;
 import com.distributedscheduler.dto.TaskRequest;
 import com.distributedscheduler.model.Task;
 import com.distributedscheduler.model.TaskStatus;
+import com.distributedscheduler.redis.RedisDelayQueueService;
 import com.distributedscheduler.repository.TaskRedisRepository;
-import com.distributedscheduler.service.impl.RedisDelayQueueService;
 import com.distributedscheduler.service.impl.TaskServiceImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -64,7 +64,7 @@ public class TaskServiceTest {
         assertEquals("generate-report", result.getName());
         assertEquals(TaskStatus.PENDING, result.getStatus());
         verify(taskRedisRepository, times(1)).save(any(Task.class));
-        verify(redisDelayQueueService, never()).addTaskToDelayQueue(anyString(), anyInt());
+        verify(redisDelayQueueService, never()).addTaskToDelayQueue(anyString(), anyString(), anyInt());
     }
 
     @Test
@@ -96,7 +96,7 @@ public class TaskServiceTest {
         // Assert
         assertEquals("delayed-task", result.getName());
         assertEquals(30, result.getDelaySeconds());
-        verify(redisDelayQueueService, times(1)).addTaskToDelayQueue(result.getId(), 30);
+        verify(redisDelayQueueService, times(1)).addTaskToDelayQueue(result.getId(),result.getTenantId(), 30);
         verify(taskRedisRepository, times(1)).save(any(Task.class));
     }
 }


### PR DESCRIPTION
…e and tenant isolation

- Store task metadata in Redis Hash with key format task:{tenantId}:{taskId}
- Use Redis ZSET for delayed execution with score = now + delaySeconds
- Ensure consistent key naming and multi-tenant support
- Add unit and integration tests for Redis persistence and delay queue
- Confirmed via Redis CLI, RedisInsight, and Postman

Closes #<issue-id> - Redis-backed task persistence