### PR TITLE
feat: implement GET /tasks/{id} to fetch task metadata from Redis

### DIFF
--- a/runner/src/main/java/com/distributedscheduler/controller/TaskController.java
+++ b/runner/src/main/java/com/distributedscheduler/controller/TaskController.java
@@ -34,4 +34,13 @@ public class TaskController {
 
         return ResponseEntity.ok(response);
     }
+
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Task> getTaskById(
+            @PathVariable String id,
+            @RequestHeader("X-Tenant-ID") String tenantId) {
+        Task task = taskService.getTaskById(tenantId, id);
+        return ResponseEntity.ok(task);
+    }
 }

--- a/runner/src/main/java/com/distributedscheduler/exception/TaskNotFoundException.java
+++ b/runner/src/main/java/com/distributedscheduler/exception/TaskNotFoundException.java
@@ -1,0 +1,15 @@
+package com.distributedscheduler.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * Exception thrown when a task with the given ID is not found in Redis.
+ */
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class TaskNotFoundException extends RuntimeException {
+
+    public TaskNotFoundException(String taskId) {
+        super("Task not found with ID: " + taskId);
+    }
+}

--- a/runner/src/main/java/com/distributedscheduler/service/TaskService.java
+++ b/runner/src/main/java/com/distributedscheduler/service/TaskService.java
@@ -17,4 +17,8 @@ public interface TaskService {
      */
     Task createTask(TaskRequest request);
 
+
+    Task getTaskById(String tenantId, String taskId);
+
+
 }

--- a/runner/src/test/java/com/distributedscheduler/service.impl/TaskServiceImplTest.java
+++ b/runner/src/test/java/com/distributedscheduler/service.impl/TaskServiceImplTest.java
@@ -4,10 +4,12 @@ import com.distributedscheduler.dto.TaskRequest;
 import com.distributedscheduler.model.Task;
 import com.distributedscheduler.model.TaskStatus;
 import com.distributedscheduler.redis.RedisDelayQueueService;
+import com.distributedscheduler.redis.RedisTaskStore;
 import com.distributedscheduler.repository.TaskRedisRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
 import org.mockito.Mockito;
 
 import java.util.Collections;
@@ -21,12 +23,15 @@ class TaskServiceImplTest {
     private TaskRedisRepository taskRedisRepository;
     private RedisDelayQueueService redisDelayQueueService;
     private TaskServiceImpl taskService;
+    @Mock
+    private RedisTaskStore redisTaskStore;
+
 
     @BeforeEach
     void setUp() {
         taskRedisRepository = mock(TaskRedisRepository.class);
         redisDelayQueueService = mock(RedisDelayQueueService.class);
-        taskService = new TaskServiceImpl(redisDelayQueueService);
+        taskService = new TaskServiceImpl(redisDelayQueueService, redisTaskStore, taskRedisRepository);
     }
 
     @Test


### PR DESCRIPTION
- Supports tenant-based lookup using Redis key format task:{tenantId}:{taskId}
- Returns full task details including status, payload, dependencies, etc.
- Returns 404 if task not found
- Uses JSON string storage with ObjectMapper deserialization
- Tested via Postman

Note: Unit and integration tests will be added after core feature completion Closes #64