### PR TITLE
feat(dlq): implement Dead Letter Queue for failed tasks after max ret…

### DIFF
--- a/docs/Task Retry Mechanism.md
+++ b/docs/Task Retry Mechanism.md
@@ -1,0 +1,77 @@
+
+## 🔁 Task Retry Mechanism – Explained for Users
+
+When a task is submitted, your system tries to **execute it**. But sometimes, things can go wrong — like a missing input, temporary service failure, or a network timeout. This is where the **retry mechanism** comes in.
+
+---
+
+### ✅ When Will the System Retry a Task?
+
+The system automatically retries a task **if it fails during execution**, regardless of whether the payload is present or not.
+
+### Common Failure Scenarios That Trigger Retry:
+
+* The task has no required input data (empty `payload`)
+* A network issue (e.g., no internet or service timeout)
+* The backend service the task depends on is down (HTTP 500)
+* Some logic inside the task code crashes unexpectedly
+
+---
+
+### 🔁 How Many Times Will It Retry?
+
+Each task has a `maxRetries` setting. If you set `maxRetries: 3`, the system will try to execute the task:
+
+| Attempt | Delay Before Retry | What Happens            |
+| ------- | ------------------ | ----------------------- |
+| 1st     | Immediate          | First attempt           |
+| 2nd     | 2 seconds later    | Retry after 2s          |
+| 3rd     | 4 seconds later    | Retry again             |
+| 4th     | 8 seconds later    | Final retry             |
+| After   | —                  | Task is marked `FAILED` |
+
+> 🔹 The delay increases exponentially: `2s`, `4s`, `8s`...
+
+---
+
+### 🧠 Example:
+
+You submitted a task with valid payload:
+
+```json
+{
+  "name": "process-order",
+  "payload": { "orderId": "12345" },
+  "maxRetries": 3
+}
+```
+
+But during execution, the system tries to call another service (e.g., payment API), and that service fails due to a **network error**.
+
+✅ The system will **automatically retry** this task up to 3 times.
+⛔ If it still fails, the task status becomes `FAILED`.
+
+---
+
+### 📍 Why Is This Useful?
+
+Without retry:
+
+* A temporary issue would make your task fail permanently
+
+With retry:
+
+* The system waits and tries again automatically
+* You avoid manual resubmission
+* Reliability improves
+
+---
+
+### ✅ Final Statuses You Could See
+
+| Status      | Meaning                              |
+| ----------- | ------------------------------------ |
+| `COMPLETED` | Task ran successfully                |
+| `RETRYING`  | Currently waiting for the next retry |
+| `FAILED`    | All retries failed                   |
+

--- a/runner/src/main/java/com/distributedscheduler/dlq/DeadLetterQueueService.java
+++ b/runner/src/main/java/com/distributedscheduler/dlq/DeadLetterQueueService.java
@@ -1,0 +1,33 @@
+package com.distributedscheduler.dlq;
+
+import com.distributedscheduler.model.Task;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+public class DeadLetterQueueService {
+
+    private static final Logger logger = LoggerFactory.getLogger(DeadLetterQueueService.class);
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    public DeadLetterQueueService(RedisTemplate<String, Object> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+        this.objectMapper = new ObjectMapper();
+    }
+
+    public void pushToDLQ(String tenantId, Task failedTask) {
+        try {
+            String key = "dlq:" + tenantId;
+            String json = objectMapper.writeValueAsString(failedTask);
+            redisTemplate.opsForList().leftPush(key, json);
+
+            logger.warn("Task [{}] moved to DLQ for tenant [{}]", failedTask.getId(), tenantId);
+        } catch (Exception e) {
+            logger.error("Failed to push task to DLQ: {}", e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
…ries

- Introduced DeadLetterQueueService to store failed tasks in Redis List (dlq:{tenantId})
- Integrated DLQ logic into RetryHandler for tasks exceeding maxRetries
- Logged DLQ push actions with task ID and retry count
- Ensured modular design for future Kafka integration
- Task metadata persisted as JSON string for inspection and reprocessing
![image](https://github.com/user-attachments/assets/2c8d7248-4d80-458d-b91d-fb152afb0c3d)
![image](https://github.com/user-attachments/assets/2cf37302-b26e-415e-8bdc-4829580e00e6)
![image](https://github.com/user-attachments/assets/7aee4b79-a282-4e53-8b4f-9ce02ee710c9)

Closes #67